### PR TITLE
Indent: Skip bracket blocks during context search

### DIFF
--- a/indent/verilog_systemverilog.vim
+++ b/indent/verilog_systemverilog.vim
@@ -358,6 +358,15 @@ function! s:GetContextIndent()
       if l:bracket_level < 0
         call verilog_systemverilog#Verbose("Inside a '()' block.")
         return indent(l:lnum) + s:offset
+      elseif l:bracket_level > 0
+        call verilog_systemverilog#Verbose("Inside a '()' block. Skipping the whole block.")
+        while l:bracket_level > 0
+          let l:lnum = s:SearchForBlockStart('(', '', ')', l:lnum, 0)
+          let l:line = s:GetLineStripped(l:lnum)
+          let l:bracket_level +=
+                \ s:CountMatches(l:line, ')') - s:CountMatches(l:line, '(')
+        endwhile
+        call verilog_systemverilog#Verbose("End of '()' block found at line " . l:lnum . ".")
       endif
     endif
 
@@ -367,6 +376,15 @@ function! s:GetContextIndent()
       if l:cbracket_level < 0
         call verilog_systemverilog#Verbose("Inside a '{}' block.")
         return indent(l:lnum) + s:offset + l:open_offset
+      elseif l:cbracket_level > 0
+        call verilog_systemverilog#Verbose("Inside a '{}' block. Skipping the whole block.")
+        while l:cbracket_level > 0
+          let l:lnum = s:SearchForBlockStart('{', '', '}', l:lnum, 0)
+          let l:line = s:GetLineStripped(l:lnum)
+          let l:cbracket_level +=
+                \ s:CountMatches(l:line, '}') - s:CountMatches(l:line, '{')
+        endwhile
+        call verilog_systemverilog#Verbose("End of '{}' block found at line " . l:lnum . ".")
       endif
     endif
 

--- a/test/indent.sv
+++ b/test/indent.sv
@@ -1079,4 +1079,23 @@ package automatic regmodel_dpi_pkg;
 endpackage
 // End of copied code
 
+// Code from: // https://github.com/vhda/verilog_systemverilog.vim/issues/231
+class my_class;
+
+    int my_var;
+
+    constraint reg_addr_c {
+        `ifndef MY_MACRO
+            my_var == 2;
+        `else
+            my_var == 3;
+        `endif
+    }
+
+    function new();
+    endfunction
+
+endclass
+// End of copied code
+
 // vi: set expandtab softtabstop=4 shiftwidth=4:

--- a/test/indent.sv.html
+++ b/test/indent.sv.html
@@ -1081,6 +1081,25 @@ do_something_else<span class="Special">;</span>
 <span class="Statement">endpackage</span>
 <span class="Comment">// End of copied code</span>
 
+<span class="Comment">// Code from: // <a href="https://github.com/vhda/verilog_systemverilog.vim/issues/231">https://github.com/vhda/verilog_systemverilog.vim/issues/231</a></span>
+<span class="Statement">class</span> my_class<span class="Special">;</span>
+
+    <span class="Statement">int</span> my_var<span class="Special">;</span>
+
+    <span class="Statement">constraint</span> reg_addr_c <span class="Special">{</span>
+        <span class="PreProc">`ifndef</span> <span class="Constant">MY_MACRO</span>
+            my_var <span class="Special">==</span> <span class="Constant">2</span><span class="Special">;</span>
+        <span class="PreProc">`else</span>
+            my_var <span class="Special">==</span> <span class="Constant">3</span><span class="Special">;</span>
+        <span class="PreProc">`endif</span>
+    <span class="Special">}</span>
+
+    <span class="Statement">function</span> <span class="Identifier">new</span><span class="Special">();</span>
+    <span class="Statement">endfunction</span>
+
+<span class="Statement">endclass</span>
+<span class="Comment">// End of copied code</span>
+
 <span class="Comment">// vi&#0058; set expandtab softtabstop=4 shiftwidth=4:</span>
 </pre>
 </body>


### PR DESCRIPTION
Fixes vhda/verilog_systemverilog.vim#231